### PR TITLE
Actualizar tarjetas y duraciones de servicios

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -515,15 +515,22 @@ header {
 
 .team-card {
   text-align: center;
-  padding-top: 2.5rem;
   width: 100%;
+  max-width: 280px;
+  aspect-ratio: 1 / 1;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
 }
 
 .team-avatar {
-  width: 96px;
-  height: 96px;
-  border-radius: 32px;
-  margin: 0 auto 1.2rem;
+  width: 92px;
+  height: 92px;
+  border-radius: 28px;
+  margin: 0;
   background: linear-gradient(145deg, rgba(45, 197, 201, 0.8), rgba(57, 217, 138, 0.7));
   position: relative;
   overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -101,6 +101,30 @@
           <h3>Prevención para pies de riesgo</h3>
           <p>Planificación de cuidados para pacientes diabéticos, deportistas y adultos mayores con seguimiento cercano.</p>
         </article>
+        <article class="card service-card fade-in" style="--delay: .43s;">
+          <span class="service-icon">
+            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <circle cx="14" cy="14" r="11" stroke="currentColor" stroke-width="2" opacity="0.45"/>
+              <path d="M10 18C10 15.7909 11.7909 14 14 14C16.2091 14 18 15.7909 18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M9 10.5C9.8 9.4 11.3 8.7 12.8 8.7C14.3 8.7 15.7 9.4 16.6 10.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M7.5 19L10.5 22M17.5 22L20.5 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
+            </svg>
+          </span>
+          <h3>Manejo de uñas encarnadas</h3>
+          <p>Procedimientos conservadores, curaciones avanzadas y alivio inmediato del dolor con control posterior incluido.</p>
+        </article>
+        <article class="card service-card fade-in" style="--delay: .5s;">
+          <span class="service-icon">
+            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <rect x="6" y="6" width="16" height="16" rx="5" stroke="currentColor" stroke-width="2"/>
+              <path d="M11 14H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M8.5 20.5L10.5 18.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
+            </svg>
+          </span>
+          <h3>Curaciones y regeneración</h3>
+          <p>Tratamientos de heridas, fisuras y úlceras con insumos estériles y terapia regenerativa para una recuperación segura.</p>
+        </article>
       </div>
       <ul class="service-list fade-in" style="--delay: .35s;">
         <li>Esterilización validada de instrumental con autoclave clase B.</li>

--- a/servicios.html
+++ b/servicios.html
@@ -42,7 +42,7 @@
             </svg>
           </span>
           <h3>Evaluación podológica</h3>
-          <p>30 minutos dedicados a anamnesis, examen clínico, identificación de factores de riesgo y diseño del plan terapéutico.</p>
+          <p>15 minutos dedicados a anamnesis, examen clínico, identificación de factores de riesgo y diseño del plan terapéutico.</p>
         </article>
         <article class="card service-card fade-in" style="--delay:.16s;">
           <span class="service-icon">
@@ -52,7 +52,7 @@
             </svg>
           </span>
           <h3>Tratamiento integral</h3>
-          <p>60 minutos para higiene profunda, fresado y reconstrucción de uñas, deslaminación de callosidades y masaje terapéutico.</p>
+          <p>30-60 minutos para higiene profunda, fresado y reconstrucción de uñas, deslaminación de callosidades y masaje terapéutico.</p>
         </article>
         <article class="card service-card fade-in" style="--delay:.22s;">
           <span class="service-icon">
@@ -63,13 +63,12 @@
             </svg>
           </span>
           <h3>Control y mantención</h3>
-          <p>40 minutos de seguimiento clínico para mantener resultados, prevenir lesiones y educar sobre autocuidado diario.</p>
+          <p>20-30 minutos de seguimiento clínico para mantener resultados, prevenir lesiones y educar sobre autocuidado diario.</p>
         </article>
       </div>
       <ul class="service-list fade-in" style="--delay:.28s;">
         <li>Onicocriptosis (uña encarnada) con técnicas conservadoras y curación avanzada.</li>
         <li>Atención a pacientes diabéticos con evaluación vascular y neurológica.</li>
-        <li>Ortesis de silicona personalizadas para alineación digital.</li>
         <li>Tratamientos para verrugas plantares, micosis, hiperhidrosis y pie de atleta.</li>
         <li>Podología estética saludable: spa podal, exfoliaciones y terapias hidratantes.</li>
       </ul>


### PR DESCRIPTION
## Summary
- add two nuevas tarjetas clínicas en el inicio para destacar manejo de uñas encarnadas y curaciones regenerativas
- ajustar la tarjeta del equipo experto para que adopte un formato cuadrado compacto
- actualizar las duraciones y lista de prestaciones en la página de servicios eliminando la ortesis personalizada

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d58ddc8df083309dc6f0f10b43c2b3