### PR TITLE
Refina alineaciones tipográficas del sitio

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -235,6 +235,11 @@ header {
 .hero-content {
   position: relative;
   z-index: 2;
+  display: grid;
+  gap: 1.4rem;
+  align-content: flex-start;
+  text-align: left;
+  justify-items: start;
 }
 
 .hero-tag {
@@ -249,6 +254,7 @@ header {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-size: 0.75rem;
+  justify-self: flex-start;
 }
 
 .hero h1 {
@@ -256,7 +262,7 @@ header {
   font-weight: 700;
   font-size: 3rem;
   line-height: 1.08;
-  margin: 1.1rem 0 1rem;
+  margin: 0;
   color: var(--color-dark);
 }
 
@@ -269,7 +275,7 @@ header {
 }
 
 .hero p {
-  margin: 0 0 1.5rem;
+  margin: 0;
   font-size: 1.08rem;
   color: var(--color-muted);
   max-width: 540px;
@@ -278,13 +284,13 @@ header {
 .hero-highlights {
   display: grid;
   gap: 0.65rem;
-  margin: 1.5rem 0 2rem;
+  margin: 0;
 }
 
 .hero-highlights li {
   list-style: none;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.65rem;
   font-weight: 600;
   color: var(--color-ink);
@@ -303,6 +309,8 @@ header {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+  justify-content: flex-start;
+  align-items: center;
 }
 
 .hero-visual {
@@ -343,15 +351,20 @@ header {
 }
 
 .section-header {
-  max-width: 680px;
-  margin-bottom: 2.2rem;
+  max-width: 720px;
+  margin: 0 auto 2.2rem;
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
+  align-content: flex-start;
+  justify-items: start;
 }
 
 .section-header h2 {
   font-family: var(--font-heading);
   font-size: 2.2rem;
   line-height: 1.1;
-  margin: 0 0 0.75rem;
+  margin: 0;
   color: var(--color-dark);
 }
 
@@ -359,6 +372,7 @@ header {
   margin: 0;
   color: var(--color-muted);
   font-size: 1.02rem;
+  max-width: 640px;
 }
 
 .badge-soft {
@@ -374,6 +388,10 @@ header {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+.section-header .badge-soft {
+  justify-self: flex-start;
 }
 
 .grid-3 {
@@ -392,6 +410,15 @@ header {
   transition: var(--transition-base);
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+  align-items: stretch;
+}
+
+.card > * {
+  margin: 0;
 }
 
 .card::before {
@@ -416,8 +443,14 @@ header {
   opacity: 1;
 }
 
+.service-card {
+  display: grid;
+  gap: 0.85rem;
+  align-content: flex-start;
+}
+
 .service-card h3 {
-  margin: 1rem 0 0.6rem;
+  margin: 0;
   font-family: var(--font-heading);
   color: var(--color-dark);
   font-size: 1.3rem;
@@ -439,7 +472,7 @@ header {
   color: var(--color-turquoise);
   font-size: 1.6rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
-  margin: 0 auto;
+  margin: 0;
 }
 
 .service-list {
@@ -452,7 +485,7 @@ header {
 .service-list li {
   list-style: none;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.75rem;
   background: rgba(255, 255, 255, 0.45);
   border: 1px solid rgba(45, 197, 201, 0.2);
@@ -510,20 +543,22 @@ header {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.5rem;
-  justify-items: center;
+  justify-items: stretch;
+  align-items: stretch;
 }
 
 .team-card {
-  text-align: center;
+  text-align: left;
   width: 100%;
   max-width: 280px;
   aspect-ratio: 1 / 1;
   padding: 2rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.6rem;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.85rem;
+  justify-self: start;
 }
 
 .team-avatar {
@@ -547,7 +582,7 @@ header {
 }
 
 .team-card h3 {
-  margin: 0 0 0.4rem;
+  margin: 0;
   font-family: var(--font-heading);
   color: var(--color-dark);
   font-size: 1.25rem;
@@ -557,7 +592,7 @@ header {
   display: block;
   color: var(--color-turquoise);
   font-weight: 600;
-  margin-bottom: 0.6rem;
+  margin: 0;
 }
 
 .team-card p {
@@ -573,7 +608,7 @@ header {
 }
 
 .contact-card h3 {
-  margin: 0 0 0.8rem;
+  margin: 0;
   font-family: var(--font-heading);
   color: var(--color-dark);
 }
@@ -581,7 +616,7 @@ header {
 .contact-details {
   display: grid;
   gap: 0.6rem;
-  margin: 1.2rem 0;
+  margin: 0;
 }
 
 .contact-details p {
@@ -625,6 +660,7 @@ label {
   gap: 0.45rem;
   font-weight: 600;
   color: var(--color-dark);
+  justify-items: start;
 }
 
 .input,
@@ -664,6 +700,12 @@ textarea:focus {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.9fr) minmax(0, 0.9fr);
   gap: 1.8rem;
+}
+
+.footer > div {
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
 }
 
 footer {


### PR DESCRIPTION
## Resumen
- Ordena la tipografía del hero con un layout en cuadrícula, márgenes consistentes y viñetas alineadas.
- Reestructura encabezados de sección y tarjetas para asegurar lecturas a la izquierda en servicios, equipo y contacto.
- Ajusta listados, formularios y columnas del pie de página para lograr alineaciones uniformes en todo el sitio.

## Pruebas
- Sin pruebas automatizadas disponibles.

------
https://chatgpt.com/codex/tasks/task_b_68d58fed67a48330bcc5939e0dea3e9b