### PR TITLE
Ajusta iconografía y alineaciones en servicios

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -443,7 +443,7 @@ header {
   opacity: 1;
 }
 
-.service-card {
+.service-card { 
   display: grid;
   gap: 0.85rem;
   align-content: flex-start;
@@ -473,6 +473,91 @@ header {
   font-size: 1.6rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
   margin: 0;
+}
+
+.hero-actions--center {
+  justify-content: center;
+}
+
+.team-card--centered {
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+}
+
+.team-card--centered span,
+.team-card--centered p {
+  text-align: center;
+  width: 100%;
+}
+
+#servicios .grid-3 {
+  justify-items: center;
+}
+
+#servicios .service-card {
+  justify-items: center;
+  text-align: center;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55));
+  box-shadow: 0 20px 45px rgba(43, 150, 160, 0.18);
+}
+
+#servicios .service-icon {
+  width: 78px;
+  height: 78px;
+  border-radius: 26px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(45, 197, 201, 0.92));
+  color: #126a73;
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 4px 14px rgba(18, 106, 115, 0.35);
+  box-shadow: 0 22px 38px rgba(45, 197, 201, 0.28), inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+  position: relative;
+  overflow: hidden;
+}
+
+#servicios .service-icon::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 22px;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.85), transparent 70%);
+  opacity: 0.9;
+}
+
+.page-servicios .grid-3 {
+  justify-items: center;
+}
+
+.page-servicios .service-card {
+  justify-items: center;
+  text-align: center;
+}
+
+.page-servicios .service-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  box-shadow: 0 18px 30px rgba(37, 211, 102, 0.28), inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+  background: radial-gradient(circle at 28% 28%, rgba(255, 255, 255, 0.9), rgba(37, 211, 102, 0.95));
+  color: #0b4b1e;
+  text-shadow: 0 4px 12px rgba(11, 75, 30, 0.32);
+  position: relative;
+  overflow: hidden;
+}
+
+.page-servicios .service-icon::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border-radius: 20px;
+  background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.8), transparent 60%);
+  opacity: 0.85;
 }
 
 .service-list {

--- a/index.html
+++ b/index.html
@@ -59,69 +59,32 @@
       </div>
       <div class="grid-3">
         <article class="card service-card fade-in" style="--delay: .15s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <circle cx="14" cy="14" r="12" stroke="currentColor" stroke-width="2" opacity="0.4"/>
-              <path d="M10 14.5L12.6 17L18 11" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Evaluación clínica integral</h3>
           <p>Anamnesis, exploración podológica, diagnóstico diferencial y planificación de tratamiento según tus objetivos de salud.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .22s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M9 23C9 23 9 21 11.5 17.5C13.2 15.2 11.7 13.3 11.7 11.2C11.7 9.1 13.2 7 14.9 7C16.6 7 18.3 8.6 18.3 10.7C18.3 12.8 17 14.6 17 16.6C17 18.6 18.5 20.8 18.5 23" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M10 5.5C11 4.5 13 4 14 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Tratamiento podológico avanzado</h3>
           <p>Higiene profunda, manejo de hiperqueratosis, fresado de uñas, onicocriptosis y procedimientos con enfoque clínico riguroso.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .29s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M7 18.5C7 13.8 10.6 10 15.2 10C19.8 10 23 13.6 23 18.2C23 22.8 19.4 26 14.8 26" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M6.8 7.5L10.2 11M6.8 11L10.2 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-              <path d="M4 18H10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Controles y bienestar continuo</h3>
           <p>Programas de mantención, educación preventiva y seguimiento clínico para preservar la salud y estética de tus pies.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .36s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M6 16.5C6 12.3579 9.35786 9 13.5 9C17.6421 9 21 12.3579 21 16.5C21 20.6421 17.6421 24 13.5 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M8.5 7L11.5 10M8.5 10L11.5 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-              <path d="M5 16H9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-              <path d="M13.5 4C15.433 4 17 5.567 17 7.5C17 9.433 15.433 11 13.5 11C11.567 11 10 9.433 10 7.5C10 5.567 11.567 4 13.5 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.55"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Prevención para pies de riesgo</h3>
           <p>Planificación de cuidados para pacientes diabéticos, deportistas y adultos mayores con seguimiento cercano.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .43s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <circle cx="14" cy="14" r="11" stroke="currentColor" stroke-width="2" opacity="0.45"/>
-              <path d="M10 18C10 15.7909 11.7909 14 14 14C16.2091 14 18 15.7909 18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M9 10.5C9.8 9.4 11.3 8.7 12.8 8.7C14.3 8.7 15.7 9.4 16.6 10.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-              <path d="M7.5 19L10.5 22M17.5 22L20.5 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Manejo de uñas encarnadas</h3>
           <p>Procedimientos conservadores, curaciones avanzadas y alivio inmediato del dolor con control posterior incluido.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .5s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <rect x="6" y="6" width="16" height="16" rx="5" stroke="currentColor" stroke-width="2"/>
-              <path d="M11 14H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-              <path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-              <path d="M8.5 20.5L10.5 18.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Curaciones y regeneración</h3>
           <p>Tratamientos de heridas, fisuras y úlceras con insumos estériles y terapia regenerativa para una recuperación segura.</p>
         </article>
@@ -145,10 +108,10 @@
       <div class="section-header fade-in" style="--delay: .1s;">
         <span class="badge-soft">Equipo experto</span>
         <h2>Profesional que cuida tus pasos</h2>
-        <p>Virginia Astorga lidera cada atención con mirada clínica, cercanía y protocolos personalizados para tus necesidades.</p>
+        <p>Nuestra especialista lidera cada atención con mirada clínica, cercanía y protocolos personalizados para tus necesidades.</p>
       </div>
       <div class="team-grid">
-        <article class="card team-card fade-in" style="--delay: .15s;">
+        <article class="card team-card team-card--centered fade-in" style="--delay: .15s;">
           <span class="team-avatar"></span>
           <h3>Virginia Astorga</h3>
           <span>Podóloga Clínica — Directora</span>
@@ -173,7 +136,7 @@
             <p><strong>Horario:</strong> Lunes a sábado, 10:00 a 19:30 hrs. (con agenda previa).</p>
           </div>
           <p class="helper">También puedes escribirnos vía redes sociales. Respondemos en menos de 24 horas para orientarte y reservar tu atención.</p>
-          <div class="hero-actions" style="margin-top:1.5rem;">
+          <div class="hero-actions hero-actions--center" style="margin-top:1.5rem;">
             <a class="btn btn-primary" href="agenda.html">Agendar online</a>
             <a class="btn btn-ghost" href="contacto.html">Formulario de contacto</a>
           </div>

--- a/servicios.html
+++ b/servicios.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Poppins:wght@500;600;700;800&display=swap" rel="stylesheet">
   <link rel="icon" href="assets/icons/favicon.ico">
 </head>
-<body>
+<body class="page-servicios">
   <header>
     <nav class="navbar">
       <div class="logo">
@@ -35,33 +35,17 @@
       </div>
       <div class="grid-3">
         <article class="card service-card fade-in" style="--delay:.1s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <circle cx="14" cy="14" r="12" stroke="currentColor" stroke-width="2" opacity="0.4"/>
-              <path d="M10 14.5L12.6 17L18 11" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--whatsapp" aria-hidden="true">💬</span>
           <h3>Evaluación podológica</h3>
           <p>15 minutos dedicados a anamnesis, examen clínico, identificación de factores de riesgo y diseño del plan terapéutico.</p>
         </article>
         <article class="card service-card fade-in" style="--delay:.16s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M9 23C9 23 9 21 11.5 17.5C13.2 15.2 11.7 13.3 11.7 11.2C11.7 9.1 13.2 7 14.9 7C16.6 7 18.3 8.6 18.3 10.7C18.3 12.8 17 14.6 17 16.6C17 18.6 18.5 20.8 18.5 23" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M10 5.5C11 4.5 13 4 14 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--whatsapp" aria-hidden="true">💬</span>
           <h3>Tratamiento integral</h3>
           <p>30-60 minutos para higiene profunda, fresado y reconstrucción de uñas, deslaminación de callosidades y masaje terapéutico.</p>
         </article>
         <article class="card service-card fade-in" style="--delay:.22s;">
-          <span class="service-icon">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M7 18.5C7 13.8 10.6 10 15.2 10C19.8 10 23 13.6 23 18.2C23 22.8 19.4 26 14.8 26" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M6.8 7.5L10.2 11M6.8 11L10.2 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.45"/>
-              <path d="M4 18H10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </span>
+          <span class="service-icon service-icon--whatsapp" aria-hidden="true">💬</span>
           <h3>Control y mantención</h3>
           <p>20-30 minutos de seguimiento clínico para mantener resultados, prevenir lesiones y educar sobre autocuidado diario.</p>
         </article>


### PR DESCRIPTION
## Summary
- Reemplaza los iconos de la sección de servicios clínicos en inicio por iniciales centradas con estilo luminoso y centra la tarjeta del equipo y los botones de contacto.
- Ajusta los estilos CSS para nuevas variantes de iconos y tarjetas que añaden color y efecto de iluminación amigable.
- Sustituye los iconos de la página de servicios por emojis de WhatsApp centrados para evaluación, tratamiento y control.

## Testing
- No se ejecutaron pruebas automatizadas (sitio estático).


------
https://chatgpt.com/codex/tasks/task_b_68d5985001588330bfa9947abe13818b