### PR TITLE
Center lead team card on team page

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -628,7 +628,8 @@ header {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.5rem;
-  justify-items: stretch;
+  justify-content: center;
+  justify-items: center;
   align-items: stretch;
 }
 
@@ -643,7 +644,7 @@ header {
   align-items: flex-start;
   justify-content: flex-start;
   gap: 0.85rem;
-  justify-self: start;
+  justify-self: center;
 }
 
 .team-avatar {


### PR DESCRIPTION
## Summary
- center the professional profile card layout on the team page by updating grid alignment
- ensure the lead podologist card aligns centrally for improved presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5b0c2807883309ea4272d29b44ae8