### PR TITLE
Ajusta la presentación del logotipo en la navegación y el footer

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -90,7 +90,7 @@ header {
 .logo {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0;
   font-family: var(--font-heading);
   font-weight: 700;
   color: var(--color-dark);
@@ -98,11 +98,11 @@ header {
 }
 
 .logo-image {
-  height: 52px;
+  height: 64px;
   width: auto;
   display: block;
-  border-radius: 12px;
-  box-shadow: 0 12px 28px rgba(39, 50, 70, 0.18);
+  border-radius: 0;
+  filter: drop-shadow(0 0 18px rgba(45, 197, 201, 0.35));
 }
 
 .logo-text {

--- a/index.html
+++ b/index.html
@@ -11,9 +11,8 @@
 <body>
   <header>
     <nav class="navbar">
-      <div class="logo">
+      <div class="logo" aria-label="Podología Cochoa">
         <img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa">
-        <span class="logo-text">Podología Cochoa</span>
       </div>
       <ul class="nav-links">
         <li><a href="index.html" class="active">Inicio</a></li>
@@ -151,7 +150,7 @@
   <footer>
     <div class="footer">
       <div>
-        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"> <span class="logo-text">Podología Cochoa</span></div>
+        <div class="logo" aria-label="Podología Cochoa"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"></div>
         <p class="small">Clínica podológica con mirada médica, tecnología avanzada y una atención cercana que pone tu bienestar en el centro.</p>
         <p class="small">© 2025 Podología Cochoa. Todos los derechos reservados.</p>
       </div>


### PR DESCRIPTION
## Summary
- elimina el texto junto al isotipo para dejar solo la imagen del logotipo
- amplía el tamaño del logotipo y elimina el recuadro para que se vea sin bordes marcados
- aplica un resplandor sutil alrededor del logotipo para destacarlo sobre el fondo

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68d5ef7779448330b963150192e51f17