### PR TITLE
Remove banner text and add homepage summary

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -13,7 +13,6 @@
     <nav class="navbar">
       <div class="logo">
         <img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa">
-        <span class="logo-text">Podología Cochoa</span>
       </div>
       <ul class="nav-links">
         <li><a href="index.html">Inicio</a></li>
@@ -75,7 +74,7 @@
   <footer>
     <div class="footer">
       <div>
-        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"> <span class="logo-text">Podología Cochoa</span></div>
+        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"></div>
         <p class="small">Clínica podológica con mirada médica, tecnología avanzada y una atención cercana que pone tu bienestar en el centro.</p>
         <p class="small">© 2025 Podología Cochoa. Todos los derechos reservados.</p>
       </div>

--- a/contacto.html
+++ b/contacto.html
@@ -13,7 +13,6 @@
     <nav class="navbar">
       <div class="logo">
         <img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa">
-        <span class="logo-text">Podología Cochoa</span>
       </div>
       <ul class="nav-links">
         <li><a href="index.html">Inicio</a></li>
@@ -85,7 +84,7 @@
   <footer>
     <div class="footer">
       <div>
-        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"> <span class="logo-text">Podología Cochoa</span></div>
+        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"></div>
         <p class="small">Clínica podológica con mirada médica, tecnología avanzada y una atención cercana que pone tu bienestar en el centro.</p>
         <p class="small">© 2025 Podología Cochoa. Todos los derechos reservados.</p>
       </div>

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -105,11 +105,6 @@ header {
   filter: drop-shadow(0 0 18px rgba(45, 197, 201, 0.35));
 }
 
-.logo-text {
-  display: inline-block;
-  line-height: 1;
-}
-
 .nav-links {
   list-style: none;
   display: flex;
@@ -392,6 +387,44 @@ header {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1.8rem;
+}
+
+.summary-card {
+  gap: 0.75rem;
+}
+
+.summary-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  color: var(--color-dark);
+}
+
+.summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+  color: var(--color-muted);
+  font-size: 0.96rem;
+}
+
+.summary-list li {
+  position: relative;
+  padding-left: 1.3rem;
+}
+
+.summary-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-turquoise);
+  box-shadow: 0 0 0 3px rgba(45, 197, 201, 0.18);
 }
 
 .card {
@@ -788,6 +821,20 @@ textarea:focus {
   text-align: left;
 }
 
+.footer > div:first-child {
+  text-align: center;
+  justify-items: center;
+}
+
+.footer > div:first-child .logo {
+  justify-content: center;
+  margin: 0 auto;
+}
+
+.footer > div:first-child .logo-image {
+  height: 80px;
+}
+
 footer {
   background: linear-gradient(140deg, #12303a 0%, #1c4553 65%, #12303a 100%);
   color: rgba(255, 255, 255, 0.9);
@@ -949,6 +996,10 @@ footer .small {
     height: 46px;
   }
 
+  .footer > div:first-child .logo-image {
+    height: 68px;
+  }
+
   .nav-links {
     order: 3;
     flex-wrap: wrap;
@@ -979,6 +1030,10 @@ footer .small {
 
   .logo-image {
     height: 42px;
+  }
+
+  .footer > div:first-child .logo-image {
+    height: 60px;
   }
 
   .hero-highlights li {

--- a/index.html
+++ b/index.html
@@ -33,11 +33,11 @@
       <div class="hero-content fade-in" style="--delay: .05s;">
         <span class="hero-tag">Clínica podológica certificada</span>
         <h1>Salud, belleza y comodidad <span>a sus pies</span></h1>
-        <p>Brindamos atención clínica especializada para el cuidado integral de tus pies. Higiene rigurosa, tecnología moderna y profesionales comprometidos con tu bienestar.</p>
+        <p>Atención clínica especializada con bioseguridad certificada y tecnología moderna para el cuidado integral de tus pies.</p>
         <ul class="hero-highlights">
-          <li>Protocolos estériles y equipamiento de grado médico.</li>
-          <li>Tratamientos personalizados para cada necesidad podológica.</li>
-          <li>Agenda flexible y acompañamiento cercano en cada visita.</li>
+          <li>Instrumental estéril y equipamiento médico validado.</li>
+          <li>Planes terapéuticos diseñados según cada diagnóstico.</li>
+          <li>Acompañamiento cercano antes y después de tu sesión.</li>
         </ul>
         <div class="hero-actions">
           <a class="btn btn-primary" href="agenda.html">Agendar evaluación clínica</a>
@@ -46,7 +46,38 @@
       </div>
       <div class="hero-visual slide-in" style="--delay: .15s;">
         <img src="assets/img/hero.jpg" alt="Atención podológica profesional">
-        <div class="note">Estamos ubicados en <strong>Cochoa 0716, Puente Alto</strong>. Atendemos de lunes a sábado, entre 10:00 y 19:30 horas, exclusivamente con reserva previa.</div>
+        <div class="note">Estamos en <strong>Cochoa 0716, Puente Alto</strong>. Atendemos de lunes a sábado, 10:00 a 19:30 horas, con reserva previa.</div>
+      </div>
+    </section>
+
+    <section class="section section-overview" id="resumen">
+      <div class="section-header fade-in" style="--delay: .1s;">
+        <span class="badge-soft">Resumen</span>
+        <h2>Lo esencial de nuestra clínica</h2>
+        <p>Una vista rápida de lo que encontrarás en la página de inicio y en tu próxima visita.</p>
+      </div>
+      <div class="grid-3 summary-grid">
+        <article class="card summary-card fade-in" style="--delay: .16s;">
+          <h3>Servicios principales</h3>
+          <ul class="summary-list">
+            <li>Evaluaciones clínicas para diagnósticos precisos.</li>
+            <li>Tratamientos avanzados que combinan salud y estética podal.</li>
+          </ul>
+        </article>
+        <article class="card summary-card fade-in" style="--delay: .22s;">
+          <h3>Experiencia profesional</h3>
+          <ul class="summary-list">
+            <li>Más de 8 años de práctica clínica certificada.</li>
+            <li>Acompañamiento educativo para prolongar los resultados.</li>
+          </ul>
+        </article>
+        <article class="card summary-card fade-in" style="--delay: .28s;">
+          <h3>Cómo agendar</h3>
+          <ul class="summary-list">
+            <li>Reserva online, por WhatsApp o vía correo electrónico.</li>
+            <li>Horario extendido de lunes a sábado con previa coordinación.</li>
+          </ul>
+        </article>
       </div>
     </section>
 
@@ -54,50 +85,50 @@
       <div class="section-header fade-in" style="--delay: .1s;">
         <span class="badge-soft">Servicios clínicos</span>
         <h2>Soluciones podológicas con enfoque médico</h2>
-        <p>Diagnóstico, tratamiento y seguimiento de patologías del pie con un protocolo integral que prioriza tu seguridad, confort e imagen personal.</p>
+        <p>Diagnóstico, tratamiento y seguimiento que priorizan tu seguridad, confort y bienestar estético.</p>
       </div>
       <div class="grid-3">
         <article class="card service-card fade-in" style="--delay: .15s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Evaluación clínica integral</h3>
-          <p>Anamnesis, exploración podológica, diagnóstico diferencial y planificación de tratamiento según tus objetivos de salud.</p>
+          <p>Anamnesis, exploración clínica y plan terapéutico ajustado a tus objetivos de salud.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .22s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Tratamiento podológico avanzado</h3>
-          <p>Higiene profunda, manejo de hiperqueratosis, fresado de uñas, onicocriptosis y procedimientos con enfoque clínico riguroso.</p>
+          <p>Higiene profunda, manejo de hiperqueratosis y procedimientos clínicos para aliviar molestias.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .29s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Controles y bienestar continuo</h3>
-          <p>Programas de mantención, educación preventiva y seguimiento clínico para preservar la salud y estética de tus pies.</p>
+          <p>Programas de mantención, educación preventiva y controles periódicos.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .36s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Prevención para pies de riesgo</h3>
-          <p>Planificación de cuidados para pacientes diabéticos, deportistas y adultos mayores con seguimiento cercano.</p>
+          <p>Cuidados para pacientes diabéticos, deportistas y adultos mayores con seguimiento cercano.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .43s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Manejo de uñas encarnadas</h3>
-          <p>Procedimientos conservadores, curaciones avanzadas y alivio inmediato del dolor con control posterior incluido.</p>
+          <p>Procedimientos conservadores, curaciones avanzadas y alivio inmediato del dolor.</p>
         </article>
         <article class="card service-card fade-in" style="--delay: .5s;">
           <span class="service-icon service-icon--clinico" aria-hidden="true">SC</span>
           <h3>Curaciones y regeneración</h3>
-          <p>Tratamientos de heridas, fisuras y úlceras con insumos estériles y terapia regenerativa para una recuperación segura.</p>
+          <p>Tratamientos de heridas, fisuras y úlceras con insumos estériles y terapia regenerativa.</p>
         </article>
       </div>
       <ul class="service-list fade-in" style="--delay: .35s;">
         <li>Esterilización validada de instrumental con autoclave clase B.</li>
         <li>Podología clínica para pacientes diabéticos y deportistas.</li>
         <li>Tratamiento de uñas encarnadas, verrugas plantares y callosidades.</li>
-        <li>Protocolos de podología estética y spa podal saludable.</li>
+        <li>Protocolos estéticos y spa podal con enfoque saludable.</li>
       </ul>
       <div class="feature-banner fade-in" style="--delay: .43s;">
         <div>
           <h3>Primera visita guiada por tu especialista</h3>
-          <p>Agenda tu evaluación inicial y recibe un plan terapéutico personalizado de Virginia Astorga. Respondemos todas tus dudas antes, durante y después del procedimiento.</p>
+          <p>Agenda tu evaluación inicial y recibe un plan personalizado de Virginia Astorga. Respondemos tus dudas en cada etapa.</p>
         </div>
         <a class="btn btn-primary" href="agenda.html">Reservar evaluación clínica</a>
       </div>
@@ -107,14 +138,14 @@
       <div class="section-header fade-in" style="--delay: .1s;">
         <span class="badge-soft">Equipo experto</span>
         <h2>Profesional que cuida tus pasos</h2>
-        <p>Nuestra especialista lidera cada atención con mirada clínica, cercanía y protocolos personalizados para tus necesidades.</p>
+        <p>Nuestra especialista lidera cada atención con mirada clínica, cercanía y protocolos a tu medida.</p>
       </div>
       <div class="team-grid">
         <article class="card team-card team-card--centered fade-in" style="--delay: .15s;">
           <span class="team-avatar"></span>
           <h3>Virginia Astorga</h3>
           <span>Podóloga Clínica — Directora</span>
-          <p>Profesional en podología integral con más de 8 años de experiencia en manejo de patologías complejas, educación preventiva y seguimiento continuo de cada paciente.</p>
+          <p>Profesional en podología integral con más de 8 años de experiencia en manejo de patologías complejas y educación preventiva.</p>
         </article>
       </div>
     </section>
@@ -123,7 +154,7 @@
       <div class="section-header fade-in" style="--delay: .1s;">
         <span class="badge-soft">Agenda y contacto</span>
         <h2>Estamos listos para recibirte con calidez clínica</h2>
-        <p>Resolvemos tus consultas, coordinamos tu atención y te acompañamos antes y después de cada sesión para asegurar resultados óptimos.</p>
+        <p>Resolvemos tus consultas, coordinamos tu atención y te acompañamos antes y después de cada sesión.</p>
       </div>
       <div class="contact-grid">
         <div class="card contact-card fade-in" style="--delay: .18s;">
@@ -134,7 +165,7 @@
             <p><strong>Dirección:</strong> Cochoa 0716, Puente Alto, Santiago.</p>
             <p><strong>Horario:</strong> Lunes a sábado, 10:00 a 19:30 hrs. (con agenda previa).</p>
           </div>
-          <p class="helper">También puedes escribirnos vía redes sociales. Respondemos en menos de 24 horas para orientarte y reservar tu atención.</p>
+          <p class="helper">También puedes escribirnos por redes sociales. Respondemos en menos de 24 horas para orientarte.</p>
           <div class="hero-actions hero-actions--center" style="margin-top:1.5rem;">
             <a class="btn btn-primary" href="agenda.html">Agendar online</a>
             <a class="btn btn-ghost" href="contacto.html">Formulario de contacto</a>

--- a/nosotros.html
+++ b/nosotros.html
@@ -13,7 +13,6 @@
     <nav class="navbar">
       <div class="logo">
         <img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa">
-        <span class="logo-text">Podología Cochoa</span>
       </div>
       <ul class="nav-links">
         <li><a href="index.html">Inicio</a></li>
@@ -81,7 +80,7 @@
   <footer>
     <div class="footer">
       <div>
-        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"> <span class="logo-text">Podología Cochoa</span></div>
+        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"></div>
         <p class="small">Clínica podológica con mirada médica, tecnología avanzada y una atención cercana que pone tu bienestar en el centro.</p>
         <p class="small">© 2025 Podología Cochoa. Todos los derechos reservados.</p>
       </div>

--- a/servicios.html
+++ b/servicios.html
@@ -13,7 +13,6 @@
     <nav class="navbar">
       <div class="logo">
         <img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa">
-        <span class="logo-text">Podología Cochoa</span>
       </div>
       <ul class="nav-links">
         <li><a href="index.html">Inicio</a></li>
@@ -91,7 +90,7 @@
   <footer>
     <div class="footer">
       <div>
-        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"> <span class="logo-text">Podología Cochoa</span></div>
+        <div class="logo"><img class="logo-image" src="assets/cochoa%20nuevo%201.png" alt="Logotipo Podología Cochoa"></div>
         <p class="small">Clínica podológica con mirada médica, tecnología avanzada y una atención cercana que pone tu bienestar en el centro.</p>
         <p class="small">© 2025 Podología Cochoa. Todos los derechos reservados.</p>
       </div>


### PR DESCRIPTION
## Summary
- remove the “Podología Cochoa” label from navigation and footer banners across the site
- add a concise overview section and tighten homepage copy to summarise the main offerings
- center and enlarge the footer logo with responsive adjustments for smaller screens

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d5f2d10a3c8330aa216b1695eca47f